### PR TITLE
Fix stillSaving text from being broken.

### DIFF
--- a/src/main/java/com/kingcontaria/fastquit/FastQuit.java
+++ b/src/main/java/com/kingcontaria/fastquit/FastQuit.java
@@ -121,7 +121,7 @@ public final class FastQuit implements ClientModInitializer {
 
         Screen oldScreen = client.currentScreen;
 
-        Text stillSaving = TextHelper.translatable("screen.fastquit.waiting", String.join("\" & \"", servers.stream().map(server -> server.getSaveProperties().getLevelName()).toList()));
+        Text stillSaving = TextHelper.translatable("fastquit.screen.waiting", String.join("\" & \"", servers.stream().map(server -> server.getSaveProperties().getLevelName()).toList()));
         log(stillSaving.getString());
 
         servers.forEach(server -> server.getThread().setPriority(Thread.NORM_PRIORITY));


### PR DESCRIPTION
Addresses an minor issue where FastQuit does not display the stillSaving text properly which causes the text to use untranslated version of it's string instead.